### PR TITLE
nixos: introduce [probably broken] shell aliases to bash for nix-darwin

### DIFF
--- a/nixos/hosts/brahms.nix
+++ b/nixos/hosts/brahms.nix
@@ -12,6 +12,7 @@
 
     ../packages/system.nix
     ../users/nobe4.nix
+    ../modules/bash.nix
   ];
 
   networking = {

--- a/nixos/modules/bash.nix
+++ b/nixos/modules/bash.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfge = config.environment;
+  cfg = config.programs.bash;
+
+  bashAliases = builtins.concatStringsSep "\n" (
+    lib.mapAttrsToList (k: v: "alias -- ${k}=${lib.escapeShellArg v}") (
+      lib.filterAttrs (k: v: v != null) cfg.shellAliases
+    )
+  );
+in {
+  options = {
+    programs.bash = {
+      shellAliases = lib.mkOption {
+        default = { };
+        description = ''
+          Set of aliases for bash shell, which overrides {option}`environment.shellAliases`.
+          See {option}`environment.shellAliases` for an option format description.
+        '';
+        type = with lib.types; attrsOf (nullOr (either str path));
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    programs.bash = {
+      # not sure if this line works?
+      shellAliases = builtins.mapAttrs (name: lib.mkDefault) cfge.shellAliases;
+      interactiveShellInit = ''
+        # Load Custom Shell Aliases
+        ${bashAliases}
+      '';
+    };
+  };
+}


### PR DESCRIPTION
This is an example of adding extra options (and logic) to an existing module. Not quite a traditional "overlay" but in my head I always consider it an overlay as it adds to the eixsting module's settings.

This probably won't work out of the box but should give you enough to get started!
